### PR TITLE
Update yonce.theme.bash to display virtualenvs

### DIFF
--- a/yonce.theme.bash
+++ b/yonce.theme.bash
@@ -110,7 +110,7 @@ __YONCE_PROMPT_CHAR_PS1=${THEME_PROMPT_CHAR_PS1:-"└"}
 __YONCE_PROMPT_CHAR_PS2=${THEME_PROMPT_CHAR_PS2:-"└"}
 
 ___YONCE_PREFIX=${___YONCE_PREFIX:-"lyric"}
-___YONCE_TOP_LEFT=${___YONCE_TOP_LEFT:-"user host dir scm"}
+___YONCE_TOP_LEFT=${___YONCE_TOP_LEFT:-"user host dir scm virtualenv"}
 ___YONCE_TOP_RIGHT=${___YONCE_TOP_RIGHT:-"exitcode node python todo clock battery"}
 ___YONCE_BOTTOM=${___YONCE_BOTTOM:-"char"}
 
@@ -307,6 +307,15 @@ ___yonce_prompt_host() {
 	printf "%s|%s" "${separator}" "${icon}" "${info}"
 }
 
+___yonce_prompt_virtualenv(){
+	if test -z ${VIRTUAL_ENV} ; then
+     info=""
+  	else
+	 info="${bold_red}(`basename \"${VIRTUAL_ENV}\"`)"
+	 printf "%s" "${info}"
+	fi
+	
+}
 ___yonce_prompt_dir() {
 	icon="${white} "
 	info="${THEME_COLOR_CWD}${__YONCE_CWD}"


### PR DESCRIPTION
<img width="556" alt="Screen Shot 2020-05-11 at 10 34 43 AM" src="https://user-images.githubusercontent.com/6998954/81573843-0a352a80-9373-11ea-98bb-4951f9354ff1.png">

I updated the script in order to indicate when a user is within a virtual environment. Virtual environments are common in Python development https://docs.python-guide.org/dev/virtualenvs/ 

 I am not sure if it makes more sense to append direct to the `___yonce_prompt_dir()` instead of creating a separate function. I am also not sure why when the function is separated it is adding additional space. I can look into further refining if this functionality is of interest.