### PR TITLE
Added Windows Terminal theming

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ OR
 
 **Note: Yoncé color scheme files reflects only the theme colors in the command prompt. To get the formatting and glyphs shown, you will need to configure your Bash theme via the instructions above.**
 
+### Windows Terminal
+
+1. Windows Terminal → `Ctrl+,`
+2. Copy text from `Yoncé.json`
+3. Paste text into `"schemes"` array
+
 ---
 
 ## Slack

--- a/Yoncé.json
+++ b/Yoncé.json
@@ -1,0 +1,21 @@
+{
+    "name": "Yonce",
+    "black": "#121212",
+    "red": "#FC4384",
+    "green": "#98E342",
+    "yellow": "#E6DB74",
+    "blue": "#00A7AA",
+    "purple": "#FFB1F2",
+    "cyan": "#37E5E7",
+    "white": "#D4D4D4",
+    "brightBlack": "#555555",
+    "brightRed": "#FC4384",
+    "brightGreen": "#98E342",
+    "brightYellow": "#E6DB74",
+    "brightBlue": "#00A7AA",
+    "brightPurple": "#FFB1F2",
+    "brightCyan": "#37E5E7",
+    "brightWhite": "#F1F1EF",
+    "background": "#1C1C1C",
+    "foreground": "#D4D4D4"
+  }


### PR DESCRIPTION
Microsoft evangelist Scott Hanselman recently released his [Scott Hanselman's 2021 Ultimate Developer and Power Users Tool List for Windows](https://www.hanselman.com/blog/scott-hanselmans-2021-ultimate-developer-and-power-users-tool-list-for-windows) which was prominently featured on the front page of [Hacker News](https://news.ycombinator.com/item?id=25534258). Yoncé was featured as his current favorite VSCode theme. I thought it might be nice for others coming from the Windows world to have an easy way to setup Windows Terminal to also use Yoncé.